### PR TITLE
Add mysql bit type

### DIFF
--- a/connectorx/src/sources/mysql/typesystem.rs
+++ b/connectorx/src/sources/mysql/typesystem.rs
@@ -31,6 +31,7 @@ pub enum MySQLTypeSystem {
     MediumBlob(bool),
     LongBlob(bool),
     Json(bool),
+    Bit(bool)
 }
 
 impl_typesystem! {
@@ -51,7 +52,7 @@ impl_typesystem! {
         { Time => NaiveTime }
         { Decimal => Decimal }
         { Char | VarChar | Enum => String }
-        { TinyBlob | Blob | MediumBlob | LongBlob => Vec<u8>}
+        { TinyBlob | Blob | MediumBlob | LongBlob | Bit => Vec<u8>}
         { Json => Value }
     }
 }
@@ -116,6 +117,7 @@ impl<'a> From<(&'a ColumnType, &'a ColumnFlags)> for MySQLTypeSystem {
             ColumnType::MYSQL_TYPE_LONG_BLOB => LongBlob(null_ok),
             ColumnType::MYSQL_TYPE_JSON => Json(null_ok),
             ColumnType::MYSQL_TYPE_VARCHAR => VarChar(null_ok),
+            ColumnType::MYSQL_TYPE_BIT => Bit(null_ok),
             _ => unimplemented!("{}", format!("{:?}", ty)),
         }
     }

--- a/connectorx/src/transports/mysql_arrow.rs
+++ b/connectorx/src/transports/mysql_arrow.rs
@@ -62,6 +62,7 @@ impl_transport!(
         { MediumBlob[Vec<u8>]        => LargeBinary[Vec<u8>]    | conversion none }
         { LongBlob[Vec<u8>]          => LargeBinary[Vec<u8>]    | conversion none }
         { Json[Value]                => LargeUtf8[String]       | conversion option }
+        { Bit[Vec<u8>]               => LargeBinary[Vec<u8>]    | conversion none  }
     }
 );
 


### PR DESCRIPTION
I've added the MySQL Bit type for arrow to allow querying tables that have it as one of the columns.
I've tested locally with a `BIT(64)` field and it works with datafusion and your `datafusion-remote-tables` implementation